### PR TITLE
Fix type conversion for types in parentheses

### DIFF
--- a/lib/pillar/type_convert/to_elixir.ex
+++ b/lib/pillar/type_convert/to_elixir.ex
@@ -1,5 +1,11 @@
 defmodule Pillar.TypeConvert.ToElixir do
   @moduledoc false
+
+  def convert("(" <> type_with_parenthese, value) do
+    {type, ")"} = String.split_at(type_with_parenthese, -1)
+    convert(type, value)
+  end
+
   def convert("String", value) do
     value
   end

--- a/test/pillar_test.exs
+++ b/test/pillar_test.exs
@@ -216,6 +216,12 @@ defmodule PillarTest do
                   }
                 ]}
     end
+
+    test "Parentheses tests", %{conn: conn} do
+      sql = "SELECT IF(0 == 1, NULL, 2) as number"
+
+      assert Pillar.select(conn, sql) == {:ok, [%{"number" => 2}]}
+    end
   end
 
   test "#query/2 - query numbers", %{conn: conn} do


### PR DESCRIPTION
Some complicated queries can produce type conversion with type given in parentheses, which results in errors like this:
```
 ** (exit) exited in: GenServer.call(#PID<0.6606.0>, {:select, "SELECT toDate(datetime) as date,cid,acid,COUNT(IF (type = 'show', 1, NULL)) as shows,COUNT (DISTINCT (IF (type = 'show', uid, NULL))) as uniq_shows,COUNT(IF (type = 'click', 1, NULL)) as clicks,IF (shows > 0, 100*clicks/shows, 0) as ctr,SUM(IF (type = 'show', price, 0)) as shows_price,IF (clicks > 0, shows_price/clicks, 0) as cpc,IF (shows > 0, shows_price/shows, 0) as cpm from events WHERE acid IN ('f096ea23-56b0-4c37-900c-200eac3fc9d4', 'd6abbdb6-7ec4-47cd-8a3f-262d3e0380e5') AND baid IN ('19227bfd-ef8e-4ec5-93ad-23dae45a3212') AND cid IN ('7d250ed6-9ece-4b40-9f42-cf13a048b89f') AND datetime >= '2019-01-01 00:00:00' AND datetime <= '2029-01-01 23:59:59' AND sid IN ('07f1d118-4d55-4b59-9515-305826803cce')  GROUP BY date,cid,acid ORDER BY date,toString(cid),toString(acid),shows,uniq_shows,clicks,ctr,shows_price,cpc,cpm", %{}, %{}}, :infinity)
         ** (EXIT) an exception was raised:
             ** (FunctionClauseError) no function clause matching in Pillar.TypeConvert.ToElixir.convert/2
                 (pillar) lib/pillar/type_convert/to_elixir.ex:3: Pillar.TypeConvert.ToElixir.convert("(UInt64)", "1")
                 (pillar) lib/pillar/response_parser.ex:48: anonymous fn/2 in Pillar.ResponseParser.convert_row/2
                 (elixir) lib/enum.ex:1340: anonymous fn/3 in Enum.map/2
                 (stdlib) maps.erl:257: :maps.fold_1/3
                 (elixir) lib/enum.ex:1964: Enum.map/2
                 (pillar) lib/pillar/response_parser.ex:47: Pillar.ResponseParser.convert_row/2
                 (elixir) lib/enum.ex:1336: Enum."-map/2-lists^map/1-0-"/2
                 (pillar) lib/pillar/response_parser.ex:17: Pillar.ResponseParser.parse/1
                 (pillar) lib/pillar/pool/worker.ex:14: Pillar.Pool.Worker.handle_call/3
                 (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
                 (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
                 (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```
