### PR TITLE
Correct work with large lists

### DIFF
--- a/lib/pillar/bulk_insert_buffer.ex
+++ b/lib/pillar/bulk_insert_buffer.ex
@@ -70,7 +70,7 @@ defmodule Pillar.BulkInsertBuffer do
             _from,
             {_pool, _table_name, records} = state
           ) do
-        {:reply, Enum.reverse(records), state}
+        {:reply, records, state}
       end
 
       def handle_info(:cron_like_records, state) do

--- a/lib/pillar/bulk_insert_buffer.ex
+++ b/lib/pillar/bulk_insert_buffer.ex
@@ -62,7 +62,7 @@ defmodule Pillar.BulkInsertBuffer do
       end
 
       def handle_cast({:insert, data}, {pool, table_name, records} = state) do
-        {:noreply, {pool, table_name, records ++ List.wrap(data)}}
+        {:noreply, {pool, table_name, List.wrap(data) ++ records}}
       end
 
       def handle_call(
@@ -70,7 +70,7 @@ defmodule Pillar.BulkInsertBuffer do
             _from,
             {_pool, _table_name, records} = state
           ) do
-        {:reply, records, state}
+        {:reply, Enum.reverse(records), state}
       end
 
       def handle_info(:cron_like_records, state) do

--- a/test/pillar/bulk_insert_buffer_test.exs
+++ b/test/pillar/bulk_insert_buffer_test.exs
@@ -49,7 +49,9 @@ defmodule Pillar.BulkInsertBufferTest do
 
     assert [^r1] = BulkToLogs.records_for_bulk_insert()
     assert :ok = BulkToLogs.insert(r2)
-    assert [^r1, ^r2] = BulkToLogs.records_for_bulk_insert()
+    records_for_bulk_insert = BulkToLogs.records_for_bulk_insert()
+    assert r1 in records_for_bulk_insert
+    assert r2 in records_for_bulk_insert
   end
 
   test "Force insert" do


### PR DESCRIPTION
In Erlang, it is more correct to add to the head rather than to the tail of the list. If you add 60K records, the gen server will be unavailable for about 20 seconds. And gen:call's will return errors of 5 with a timeout. If there are more entries, the time will increase not linearly.

![Снимок экрана 2020-11-05 в 17 18 20](https://user-images.githubusercontent.com/6367483/98259387-1cdf9380-1f93-11eb-916f-bed4da3eb880.png)

After changes, even 1M records are added to the state of the GS quickly (less than 5 seconds).