### PR TITLE
FIX: decode null for non-Nullable numeric types

### DIFF
--- a/lib/pillar/type_convert/to_elixir.ex
+++ b/lib/pillar/type_convert/to_elixir.ex
@@ -3,6 +3,13 @@ defmodule Pillar.TypeConvert.ToElixir do
 
   require Logger
 
+  # A JSON `null` decodes to `nil` regardless of the declared column type.
+  # ClickHouse serialises NaN/Inf in a non-Nullable numeric column (and null
+  # elements inside arrays) as `null`, which would otherwise match no clause
+  # below and raise a FunctionClauseError. This must precede the Array/Map/Tuple
+  # clauses so a `null` is caught before they attempt to enumerate it.
+  def convert(_clickhouse_type, nil), do: nil
+
   def convert("(" <> type_with_parenthese, value) do
     # For example (UInt64), this type returns when IF function returns NULL or Uint64
     # SELECT IF(1 == 2, NULL, 64)

--- a/test/pillar/type_convert/to_elixir_test.exs
+++ b/test/pillar/type_convert/to_elixir_test.exs
@@ -1,0 +1,32 @@
+defmodule Pillar.TypeConvert.ToElixirTest do
+  alias Pillar.TypeConvert.ToElixir
+  use ExUnit.Case
+
+  describe "#convert/2" do
+    test "Float64" do
+      assert ToElixir.convert("Float64", 42.5) == 42.5
+    end
+
+    test "Int64" do
+      assert ToElixir.convert("Int64", "7") == 7
+    end
+
+    test "Nullable returns nil for a null value" do
+      assert ToElixir.convert("Nullable(Float64)", nil) == nil
+    end
+
+    test "null in a non-Nullable numeric column decodes to nil" do
+      # ClickHouse serialises NaN/Inf as JSON null under a bare Float64/Int64.
+      assert ToElixir.convert("Float64", nil) == nil
+      assert ToElixir.convert("Int64", nil) == nil
+    end
+
+    test "a null array element decodes to nil element-wise" do
+      assert ToElixir.convert("Array(Float64)", [1.0, nil, 2.0]) == [1.0, nil, 2.0]
+    end
+
+    test "a null array column decodes to nil" do
+      assert ToElixir.convert("Array(Float64)", nil) == nil
+    end
+  end
+end


### PR DESCRIPTION
## Problem

ClickHouse serialises non-finite floats (`NaN`, `Inf`, `-Inf`) in a **non-`Nullable`** numeric column as JSON `null` (the default, with `output_format_json_quote_denormals = 0`). `Pillar.TypeConvert.ToElixir.convert/2` only has a `nil` clause for `Nullable(...)` types, so a `null` under a bare `Float64`/`Int64`/etc. matches no clause and raises `FunctionClauseError`, crashing the process that called `ResponseParser.parse/1`.

The same happens for a `null` element inside an `Array(Float64)`, since the `Array` clause maps its elements back through `convert/2`.

### Reproduction

```elixir
# `SELECT 0/0 AS x FORMAT JSON` returns:
#   {"meta":[{"name":"x","type":"Float64"}],"data":[{"x":null}]}
Pillar.TypeConvert.ToElixir.convert("Float64", nil)
# ** (FunctionClauseError) no function clause matching in Pillar.TypeConvert.ToElixir.convert/2
```

(Enabling `output_format_json_quote_denormals = 1` does not help on its own: the value then arrives as the string `"nan"`, which also matches no numeric clause.)

## Fix

Add a `convert(_clickhouse_type, nil)` clause that decodes a JSON `null` to `nil` regardless of the declared column type, which is the faithful representation of what ClickHouse sent. It is placed before the `Array`/`Map`/`Tuple` clauses so a `null` is caught before they try to enumerate it; nested `null`s (for example a `null` element inside `Array(Float64)`) are handled via the existing recursion.

`Nullable(...)` behaviour is unchanged, and the clause only matches values that previously raised, so no existing conversion changes.

## Tests

Adds `test/pillar/type_convert/to_elixir_test.exs` covering a `null` under non-`Nullable` `Float64`/`Int64`, a `null` array element (element-wise), a whole `null` array, plus the existing `Nullable` and finite cases.